### PR TITLE
Fixed deserialisation of Required specifications which were appearing as Optional.

### DIFF
--- a/Xbim.InformationSpecifications.NewTests/Constraints/CardinalityTests.cs
+++ b/Xbim.InformationSpecifications.NewTests/Constraints/CardinalityTests.cs
@@ -50,7 +50,7 @@ namespace Xbim.InformationSpecifications.Tests.Constraints
         [Fact]
         public void MinMaxCardinality_IsSatisfiedBy_Works()
         {
-            var sc = new MinMaxCardinality(); // defaults to optional
+            var sc = new MinMaxCardinality(0); // defaults to required: 0 = optional
             sc.IsSatisfiedBy(0).Should().BeTrue();
             sc.IsSatisfiedBy(1).Should().BeTrue();
             sc.IsSatisfiedBy(10).Should().BeTrue();
@@ -80,7 +80,10 @@ namespace Xbim.InformationSpecifications.Tests.Constraints
         [Fact]
         public void MinMaxCardinality_Conversion_Works()
         {
-            var sc = new MinMaxCardinality(); // defaults to optional
+            var sc = new MinMaxCardinality(); // defaults to required
+            sc.Simplify().Should().BeEquivalentTo(new SimpleCardinality(CardinalityEnum.Required));
+
+            sc = new MinMaxCardinality(0); // minOccurs:0 = optional
             sc.Simplify().Should().BeEquivalentTo(new SimpleCardinality(CardinalityEnum.Optional));
 
             sc = new MinMaxCardinality(1); // minimum one -> required

--- a/Xbim.InformationSpecifications.NewTests/IoTests.cs
+++ b/Xbim.InformationSpecifications.NewTests/IoTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using Xbim.InformationSpecifications.Cardinality;
 using Xbim.InformationSpecifications.Tests.Helpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -251,6 +252,60 @@ namespace Xbim.InformationSpecifications.Tests
 
             newIds.Should().NotBeNull();
             newIds!.SpecificationsGroups.Should().HaveCount(2);
+        }
+
+        [InlineData(CardinalityEnum.Required)]
+        [InlineData(CardinalityEnum.Optional)]
+        [InlineData(CardinalityEnum.Prohibited)]
+        [Theory]
+        public void CanRoundTripCardinalityInXml(CardinalityEnum cardinality)
+        {
+            var filename = Path.ChangeExtension(Path.GetTempFileName(), "ids");
+            try
+            {
+
+
+                Xids x = XidsTestHelpers.GetSimpleXids();
+
+                x.AllSpecifications().First().Cardinality = new SimpleCardinality(cardinality);
+                x.ExportBuildingSmartIDS(filename, GetXunitLogger());
+
+                var newXids = Xids.LoadBuildingSmartIDS(filename);
+                var cardinal = newXids!.AllSpecifications().First().Cardinality;
+                cardinal.Should().BeOfType<SimpleCardinality>();
+                ((SimpleCardinality)cardinal).ApplicabilityCardinality.Should().Be(cardinality);
+            }
+            finally
+            {
+                if(File.Exists(filename)) File.Delete(filename);
+            }
+        }
+
+        [InlineData(CardinalityEnum.Required)]
+        [InlineData(CardinalityEnum.Optional)]
+        [InlineData(CardinalityEnum.Prohibited)]
+        [Theory]
+        public void CanRoundTripCardinalityInJson(CardinalityEnum cardinality)
+        {
+            var filename = Path.ChangeExtension(Path.GetTempFileName(), "ids");
+            try
+            {
+
+
+                Xids x = XidsTestHelpers.GetSimpleXids();
+
+                x.AllSpecifications().First().Cardinality = new SimpleCardinality(cardinality);
+                x.SaveAsJson(filename);
+
+                var newXids = Xids.LoadFromJson(filename);
+                var cardinal = newXids!.AllSpecifications().First().Cardinality;
+                cardinal.Should().BeOfType<SimpleCardinality>();
+                ((SimpleCardinality)cardinal).ApplicabilityCardinality.Should().Be(cardinality);
+            }
+            finally
+            {
+                if (File.Exists(filename)) File.Delete(filename);
+            }
         }
 
         private static Xids BuildMultiSpecGroupIDS()

--- a/Xbim.InformationSpecifications/Cardinality/MinMaxCardinality.cs
+++ b/Xbim.InformationSpecifications/Cardinality/MinMaxCardinality.cs
@@ -10,7 +10,7 @@ namespace Xbim.InformationSpecifications.Cardinality
     public class MinMaxCardinality : ICardinality
     {
         /// <summary>
-        /// Default constructor, Min = 0, Max = unbounded
+        /// Default constructor, Min = 1, Max = unbounded (Required)
         /// </summary>
         public MinMaxCardinality()
         {
@@ -27,9 +27,9 @@ namespace Xbim.InformationSpecifications.Cardinality
 
         /// <summary>
         /// The minimum cardinality.
-        /// Defaults to 0 (optional).
+        /// Defaults to 1 (required). This is line with XSD defaults
         /// </summary>
-        public int MinOccurs { get; set; } = 0;
+        public int MinOccurs { get; set; } = 1;
 
         /// <summary>
         /// The maximum expected cardinality.

--- a/Xbim.InformationSpecifications/Cardinality/SimpleCardinality.cs
+++ b/Xbim.InformationSpecifications/Cardinality/SimpleCardinality.cs
@@ -67,7 +67,7 @@ namespace Xbim.InformationSpecifications.Cardinality
             switch (ApplicabilityCardinality)
             {
                 case CardinalityEnum.Required:
-                    // xmlWriter.WriteAttributeString("minOccurs", "1"); // 1 is the default value, we can omit
+                    xmlWriter.WriteAttributeString("minOccurs", "1"); // the default. Set for clarity
                     xmlWriter.WriteAttributeString("maxOccurs", "unbounded");
                     break;
                 case CardinalityEnum.Optional:

--- a/Xbim.InformationSpecifications/IO/Xids.Io.xml.cs
+++ b/Xbim.InformationSpecifications/IO/Xids.Io.xml.cs
@@ -21,13 +21,20 @@ namespace Xbim.InformationSpecifications
             {
                 var settings = new XmlWriterSettings();
                 settings.Async = false;
-#if DEBUG
-                settings.Indent = true;
-                settings.IndentChars = "\t";
-#endif
+                if(PrettyOutput)
+                {
+                    settings.Indent = true;
+                    settings.IndentChars = "\t";
+                }
+
                 return settings;
             }
         }
+
+        /// <summary>
+        /// Determines if the XML output should be indented for readability
+        /// </summary>
+        public static bool PrettyOutput { get; set; } = true;
 
         /// <summary>
         /// When exporting to bS IDS, export files can be one of the formats in this enum.

--- a/Xbim.InformationSpecifications/Xbim.InformationSpecifications.csproj
+++ b/Xbim.InformationSpecifications/Xbim.InformationSpecifications.csproj
@@ -19,7 +19,7 @@
 		<AssemblyName>Xbim.InformationSpecifications</AssemblyName>
 		<RootNamespace>Xbim.InformationSpecifications</RootNamespace>
 		<!-- Remember to update the hardcoded AssemblyVersion property in XIDS-->
-		<AssemblyVersion>0.3.32</AssemblyVersion>
+		<AssemblyVersion>0.3.33</AssemblyVersion>
 		<!-- Remember to update the hardcoded AssemblyVersion property in XIDS-->
 		<FileVersion>$(AssemblyVersion)</FileVersion>
 		<Version>$(AssemblyVersion)</Version>

--- a/Xbim.InformationSpecifications/Xids.AssemblyVersion.cs
+++ b/Xbim.InformationSpecifications/Xids.AssemblyVersion.cs
@@ -7,6 +7,6 @@
         /// This is useful for environments that do not allow to load information from the DLL dynamically
         /// (e.g. Blazor).
         /// </summary>
-        public static string AssemblyVersion => "0.3.32";
+        public static string AssemblyVersion => "0.3.33";
     }
 }


### PR DESCRIPTION
We don't explicitly export minOccurs on xml Export for Required specs as the xsd minOccurs default is 1

But on load we were defaulting MinOccurs to zero (in MinMaxCardinality) and never over-riding if we had an implicit minOccurs. In turn this created the wrong SimpleCardinality when simplifying 

Fix1: made MinMaxCardinality work in line with xsd defaults (so we import correctly) i.e. minOccurs default =1
Fix2: explicitly export the minOccurs for Required (so 3rd parties can be clear of the intent, and to avoid similar bugs elsewhere)

Also allow pretty Xml be enabled/disabled  in release modes via a switch