### PR TITLE
Fix: Ignore whitespace during serialisation

### DIFF
--- a/Xbim.InformationSpecifications.NewTests/IoTests.cs
+++ b/Xbim.InformationSpecifications.NewTests/IoTests.cs
@@ -148,7 +148,7 @@ namespace Xbim.InformationSpecifications.Tests
         [Fact]
         public void ShouldIgnoreWhitespaceInElements()
         {
-            var f = new FileInfo(@"bsFiles\others\SimpleValueString_whitepace.ids");
+            var f = new FileInfo(@"bsFiles/others/SimpleValueString_whitepace.ids");
             Xids.CanLoad(f).Should().BeTrue();
 
             var x = Xids.Load(f);

--- a/Xbim.InformationSpecifications.NewTests/IoTests.cs
+++ b/Xbim.InformationSpecifications.NewTests/IoTests.cs
@@ -141,7 +141,97 @@ namespace Xbim.InformationSpecifications.Tests
             var attr = spec.Requirement.Facets.FirstOrDefault();
             attr.Should().BeOfType<AttributeFacet>();
             spec.Requirement.RequirementOptions.Should().HaveCount(1);
-            spec.Requirement.RequirementOptions!.First().Should().Be(RequirementCardinalityOptions.Optional);
+            spec.Requirement.RequirementOptions![0].Should().Be(RequirementCardinalityOptions.Optional);
+
+        }
+
+        [Fact]
+        public void ShouldIgnoreWhitespaceInElements()
+        {
+            var f = new FileInfo(@"bsFiles\others\SimpleValueString_whitepace.ids");
+            Xids.CanLoad(f).Should().BeTrue();
+
+            var x = Xids.Load(f);
+            x.Should().NotBeNull();
+
+            var spec = x!.AllSpecifications().FirstOrDefault();
+            spec.Should().NotBeNull();
+
+
+            var facets = spec!.Requirement!.Facets.Union(spec.Applicability.Facets);
+            foreach (var facet in facets)
+            {
+                switch(facet)
+                {
+                    case IfcTypeFacet type:
+                        ValidateConstraint(type.IfcType, "string");
+                        ValidateConstraint(type.PredefinedType, "string");
+                        break
+                            ;
+                    case AttributeFacet attr:
+                        ValidateConstraint(attr.AttributeName, "string");
+                        ValidateConstraint(attr.AttributeValue, "string");
+                        break;
+
+                    case IfcPropertyFacet prop:
+                        ValidateConstraint(prop.PropertySetName, "string");
+                        ValidateConstraint(prop.PropertyName, "string");
+                        ValidateConstraint(prop.PropertyValue, "string");
+                        break;
+
+                    case IfcClassificationFacet cls:
+                        ValidateConstraint(cls.ClassificationSystem, "string");
+                        ValidateConstraint(cls.Identification, "string");
+                        break;
+
+                    case MaterialFacet mat:
+                        ValidateConstraint(mat.Value, "string");
+                        break;
+
+                    case PartOfFacet part:
+                        ValidateConstraint(part.EntityType!.IfcType, "string");
+                        ValidateConstraint(part.EntityType!.PredefinedType, "string");
+                        break;
+
+                    default:
+                        Assert.Fail($"Not implemented {facet.GetType().Name}");
+                        break;
+                }
+            }
+
+
+        }
+
+        private void ValidateConstraint(ValueConstraint? constraint, string expected)
+        {
+            constraint.Should().NotBeNull();
+            if(constraint!.IsSingleExact(out var value))
+            {
+                value.ToString().Should().Be(expected);
+            }
+            else
+            {
+                if(constraint.AcceptedValues!.Count() > 1)
+                {
+                    foreach(var enumValue in constraint.AcceptedValues!)
+                    {
+                        enumValue.IsSatisfiedBy(expected, constraint, false).Should().BeTrue();
+                    }
+                } 
+                else
+                {
+                    var complexConstraint =  constraint.AcceptedValues!.FirstOrDefault();
+                    switch (complexConstraint)
+                    {
+                        case PatternConstraint p:
+                            p.Pattern.Should().Be(expected);
+                            break;
+                        case RangeConstraint r:
+                            r.MinValue.Should().Be(expected);
+                            break;
+                    }
+                }
+            }
         }
 
 

--- a/Xbim.InformationSpecifications.NewTests/Xbim.InformationSpecifications.Tests.csproj
+++ b/Xbim.InformationSpecifications.NewTests/Xbim.InformationSpecifications.Tests.csproj
@@ -120,6 +120,9 @@
     <None Update="bsFiles\others\pass-name_restrictions_will_match_any_result_1_3.ids">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="bsFiles\others\SimpleValueString_whitepace.ids">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Files\FutureFormat.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Xbim.InformationSpecifications.NewTests/bsFiles/others/SimpleValueString_whitepace.ids
+++ b/Xbim.InformationSpecifications.NewTests/bsFiles/others/SimpleValueString_whitepace.ids
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Created with Liquid Technologies Online Tools 1.0 (https://www.liquid-technologies.com) -->
+<ids:ids xmlns:ids="http://standards.buildingsmart.org/IDS" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS  ids_09.xsd">
+  <ids:info>
+    <ids:title>string</ids:title>
+    <ids:copyright>string</ids:copyright>
+    <ids:version>string</ids:version>
+    <ids:description>string</ids:description>
+    <ids:author>^@).Uj</ids:author>
+    <ids:date>2007-09-18</ids:date>
+    <ids:purpose>string</ids:purpose>
+    <ids:milestone>string</ids:milestone>
+  </ids:info>
+  <ids:specifications>
+    <ids:specification name="string" ifcVersion="IFC4 IFC2X3 IFC4X3 IFC2X3 IFC4 IFC2X3" description="string" instructions="string" minOccurs="1" maxOccurs="unbounded">
+      <ids:applicability>
+        <ids:entity>
+          <ids:name>
+            <ids:simpleValue>
+              string
+            </ids:simpleValue>
+          </ids:name>
+          <ids:predefinedType>
+            <ids:simpleValue>
+              string
+            </ids:simpleValue>
+          </ids:predefinedType>
+        </ids:entity>
+        
+        <ids:classification>
+          <ids:value>
+            <ids:simpleValue>
+              string
+            </ids:simpleValue>
+          </ids:value>
+          <ids:system>
+            <xs:restriction base="xs:string">
+              <xs:enumeration value="string"/>
+              <xs:enumeration value="string"/>
+            </xs:restriction>
+          </ids:system>
+        </ids:classification>
+        <ids:attribute>
+          <ids:name>
+            <ids:simpleValue>
+              string
+            </ids:simpleValue>
+          </ids:name>
+          <ids:value>
+            <ids:simpleValue>
+              string
+            </ids:simpleValue>
+          </ids:value>
+        </ids:attribute>
+        <ids:property>
+          <ids:propertySet>
+            <ids:simpleValue>
+              string
+            </ids:simpleValue>
+          </ids:propertySet>
+          <ids:name>
+            <xs:restriction base="xs:string">
+              <xs:pattern value="string" />
+            </xs:restriction>
+          </ids:name>
+          <ids:value>
+            <ids:simpleValue>
+              string
+            </ids:simpleValue>
+          </ids:value>
+        </ids:property>
+        <ids:material>
+          <ids:value>
+            <ids:simpleValue>
+              string
+            </ids:simpleValue>
+          </ids:value>
+        </ids:material>
+        <ids:partOf relation="IfcRelAssignsToGroup">
+          <ids:entity>
+            <ids:name>
+              <ids:simpleValue>
+                string
+              </ids:simpleValue>
+            </ids:name>
+            <ids:predefinedType>
+              <ids:simpleValue>
+                string
+              </ids:simpleValue>
+            </ids:predefinedType>
+          </ids:entity>
+        </ids:partOf>
+      </ids:applicability>
+      <ids:requirements description="string">
+        <ids:entity>
+          <ids:name>
+            <ids:simpleValue>
+              string
+            </ids:simpleValue>
+          </ids:name>
+          <ids:predefinedType>
+            <ids:simpleValue>
+              string
+            </ids:simpleValue>
+          </ids:predefinedType>
+        </ids:entity>
+        <ids:partOf instructions="string" relation="IfcRelAggregates" minOccurs="1" maxOccurs="unbounded">
+          <ids:entity>
+            <ids:name>
+              <ids:simpleValue>
+                string
+              </ids:simpleValue>
+            </ids:name>
+            <ids:predefinedType>
+              <ids:simpleValue>
+                string
+              </ids:simpleValue>
+            </ids:predefinedType>
+          </ids:entity>
+        </ids:partOf>
+        <ids:classification uri="https://www.liquid-technologies.com" instructions="string" minOccurs="1" maxOccurs="unbounded">
+          <ids:value>
+            <ids:simpleValue>
+              string
+            </ids:simpleValue>
+          </ids:value>
+          <ids:system>
+            <ids:simpleValue>
+              string
+            </ids:simpleValue>
+          </ids:system>
+        </ids:classification>
+        <ids:attribute instructions="string">
+          <ids:name>
+            <ids:simpleValue>
+              string
+            </ids:simpleValue>
+          </ids:name>
+          <ids:value>
+            <ids:simpleValue>
+              string
+            </ids:simpleValue>
+          </ids:value>
+        </ids:attribute>
+        <ids:property uri="https://www.liquid-technologies.com" instructions="string" minOccurs="1" maxOccurs="unbounded">
+          <ids:propertySet>
+            <ids:simpleValue>
+              string
+            </ids:simpleValue>
+          </ids:propertySet>
+          <ids:name>
+            <ids:simpleValue>
+              string
+            </ids:simpleValue>
+          </ids:name>
+          <ids:value>
+            <ids:simpleValue>
+              string
+            </ids:simpleValue>
+          </ids:value>
+        </ids:property>
+        <ids:material uri="https://www.liquid-technologies.com" instructions="string" minOccurs="1" maxOccurs="unbounded">
+          <ids:value>
+            <ids:simpleValue>
+              string
+            </ids:simpleValue>
+          </ids:value>
+        </ids:material>
+      </ids:requirements>
+    </ids:specification>
+  </ids:specifications>
+</ids:ids>

--- a/Xbim.InformationSpecifications/Values/ExactConstraint.cs
+++ b/Xbim.InformationSpecifications/Values/ExactConstraint.cs
@@ -16,7 +16,7 @@ namespace Xbim.InformationSpecifications
         /// <param name="value">The value of the constraint, expressed as a string</param>
         public ExactConstraint(string value)
         {
-            Value = value;
+            Value = value.Trim();
         }
 
         /// <summary>

--- a/Xbim.InformationSpecifications/Xbim.InformationSpecifications.csproj
+++ b/Xbim.InformationSpecifications/Xbim.InformationSpecifications.csproj
@@ -19,7 +19,7 @@
 		<AssemblyName>Xbim.InformationSpecifications</AssemblyName>
 		<RootNamespace>Xbim.InformationSpecifications</RootNamespace>
 		<!-- Remember to update the hardcoded AssemblyVersion property in XIDS-->
-		<AssemblyVersion>0.3.33</AssemblyVersion>
+		<AssemblyVersion>0.3.34</AssemblyVersion>
 		<!-- Remember to update the hardcoded AssemblyVersion property in XIDS-->
 		<FileVersion>$(AssemblyVersion)</FileVersion>
 		<Version>$(AssemblyVersion)</Version>

--- a/Xbim.InformationSpecifications/Xids.AssemblyVersion.cs
+++ b/Xbim.InformationSpecifications/Xids.AssemblyVersion.cs
@@ -7,6 +7,6 @@
         /// This is useful for environments that do not allow to load information from the DLL dynamically
         /// (e.g. Blazor).
         /// </summary>
-        public static string AssemblyVersion => "0.3.33";
+        public static string AssemblyVersion => "0.3.34";
     }
 }


### PR DESCRIPTION
Issue apparent in xml IDS files where line breaks/tabs etc in a simplevalue NodeText

We now trim simplevalues to more gracefully support input with insignificant whitespace.
Came about from sample IDS with (newline) whitespace in simplevalue elements content. 
This is picked up as ContentError by IdsLib schema, but this makes us more graceful. (test case was a moliohouse.ids from cobuilder)

I can't think of any scenario where leading/trailing whitespace on a ExactConstraint will be relevant... @CBenghi ?