### PR TITLE
Downgraded to net6 Logging abstraction to resolve issues in some envs

### DIFF
--- a/Xbim.InformationSpecifications/Xbim.InformationSpecifications.csproj
+++ b/Xbim.InformationSpecifications/Xbim.InformationSpecifications.csproj
@@ -49,7 +49,7 @@
 		<None Include="C:\Data\Dev\XbimPrivate\Xbim.Xids\Xbim.InformationSpecifications\.editorconfig" />
 	</ItemGroup>
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
 	  <PackageReference Include="Nullable" Version="1.3.1">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
E.g. Azure functions and xbim Geometry v6 have DI issues with newer net7 deps in a net6 app.

Workaround for now. Following up with a deeper investigation so we can revert/upgrade in future