### PR TITLE
Fixed two string case issues

### DIFF
--- a/Xbim.InformationSpecifications.NewTests/Facets/PropertyFacetTests.cs
+++ b/Xbim.InformationSpecifications.NewTests/Facets/PropertyFacetTests.cs
@@ -22,6 +22,37 @@ namespace Xbim.InformationSpecifications.Tests.Facets
             t.Equals(null).Should().BeFalse();
         }
 
+
+        [Theory]
+        [InlineData("Name", true)]
+        [InlineData("NAME", true)]
+        [InlineData("name", true)]
+        public void StringsCanBeComparedCaseInsensitively(string input, bool expectedResult)
+        {
+
+            var facet = new IfcPropertyFacet()
+            {
+                PropertyName = "Name",
+            };
+            facet.PropertyName.BaseType.Should().Be(NetTypeName.Undefined); // Why isn't this String type?
+
+            facet.PropertyName.IsSatisfiedBy(input, ignoreCase: true).Should().Be(expectedResult, "we're ignoring case");
+        }
+
+        [Fact]
+        public void EqualityWorksWhenBaseTypeSet()
+        {
+            // Equality testing when Basetype string with ExactConstraints was wrong
+            var facet = new IfcPropertyFacet()
+            {
+                PropertyName = "Name",
+            };
+            facet.PropertyName.BaseType = NetTypeName.String;
+            var copy = facet;
+
+            facet.Equals(copy).Should().BeTrue("It's the same object!");
+        }
+
         [Theory]
         [MemberData(nameof(GetDifferentAttributesPairs))]
         public void AttributeEqualNotMatchImplementation(IfcPropertyFacet one, IfcPropertyFacet other)

--- a/Xbim.InformationSpecifications/Facets/IFacetExtensions.cs
+++ b/Xbim.InformationSpecifications/Facets/IFacetExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Xbim.InformationSpecifications.Helpers;
 
 namespace Xbim.InformationSpecifications
@@ -60,7 +61,7 @@ namespace Xbim.InformationSpecifications
                     && ofTwo is ExactConstraint ecOfTwo
                     )
                 {
-                    if (ecOfOne.Value.ToUpperInvariant().Equals(ecOfTwo.Value.ToUpperInvariant()))
+                    if (!ecOfOne.Value.Equals(ecOfTwo.Value, StringComparison.InvariantCultureIgnoreCase))
                         return false;
                 }
                 else

--- a/Xbim.InformationSpecifications/Values/ExactConstraint.cs
+++ b/Xbim.InformationSpecifications/Values/ExactConstraint.cs
@@ -27,7 +27,7 @@ namespace Xbim.InformationSpecifications
         /// <inheritdoc />
         public bool IsSatisfiedBy(object candiatateValue, ValueConstraint context, bool ignoreCase, ILogger? logger = null)
         {
-            if (context.BaseType == NetTypeName.Undefined)
+            if (context.BaseType == NetTypeName.Undefined && !ignoreCase)
             {
                 // if we are comparing without a type constraint, we match the type of the 
                 // candidate, rather than converting all to string.


### PR DESCRIPTION
1. `ValueConstraint.IsSatisifedBy(val, ignoreCase: true)` would fail unless BaseType was set to String (from default of Undefined)

Fixed by always using string comparison when ignoreCase = true (which must be string)

2. When ValueConstraints had BaseType set to String, facet equality was broken

Fixed the logic, which was inversed.

TODO: Need to better understand the approach to storing and testing values ValueConstraint - it feels over-elaborate and brittle... Also unclear why we're specialcase using CaseInsensitiveEquals in just PropertySet Facets Equality