### PR TITLE
Fix/ifc type persistence with enums

### DIFF
--- a/Xbim.InformationSpecifications/Xbim.InformationSpecifications.csproj
+++ b/Xbim.InformationSpecifications/Xbim.InformationSpecifications.csproj
@@ -19,7 +19,7 @@
 		<AssemblyName>Xbim.InformationSpecifications</AssemblyName>
 		<RootNamespace>Xbim.InformationSpecifications</RootNamespace>
 		<!-- Remember to update the hardcoded AssemblyVersion property in XIDS-->
-		<AssemblyVersion>0.3.49</AssemblyVersion>
+		<AssemblyVersion>0.3.50</AssemblyVersion>
 		<!-- Remember to update the hardcoded AssemblyVersion property in XIDS-->
 		<FileVersion>$(AssemblyVersion)</FileVersion>
 		<Version>$(AssemblyVersion)</Version>

--- a/Xbim.InformationSpecifications/Xids.AssemblyVersion.cs
+++ b/Xbim.InformationSpecifications/Xids.AssemblyVersion.cs
@@ -7,6 +7,6 @@
         /// This is useful for environments that do not allow to load information from the DLL dynamically
         /// (e.g. Blazor).
         /// </summary>
-        public static string AssemblyVersion => "0.3.49";
+        public static string AssemblyVersion => "0.3.50";
     }
 }


### PR DESCRIPTION
Fix issue where IfcType not serialised when using Enum constraint.

Because IncludeSubTypes defaults to true there was an unimplemented path in the serialiser that meant outputing Entity Facets with multiple IfcTypes would lose the types, creating an invalid file.

Implemented subClass expansion more generically.