### PR TITLE
Various fixes on ValueConstraint comparison & 1e-6 support

### DIFF
--- a/Xbim.InformationSpecifications.NewTests/Constraints/ValueContraintTests.cs
+++ b/Xbim.InformationSpecifications.NewTests/Constraints/ValueContraintTests.cs
@@ -223,6 +223,21 @@ namespace Xbim.InformationSpecifications.Tests
             vc.IsSatisfiedBy(30L).Should().BeTrue("30L failure");
             vc.IsSatisfiedBy(60).Should().BeTrue("60 failure");
             vc.IsSatisfiedBy(60L).Should().BeTrue("60L failure");
-        } 
+        }
+
+        
+        [InlineData("text", "Text")]
+        [InlineData("à rénover", "A RENOVER")]
+        [InlineData("abîmer", "Abimer")]
+        [InlineData("tårn", "Tarn")]
+
+        [Theory]
+        public void CanCompareCaseInsensitivelyIgnoringAccents(string input, string constraint)
+        {
+
+            ValueConstraint vc = constraint;
+            vc.IsSatisfiedBy(input, true).Should().BeTrue();
+            
+        }
     }
 }

--- a/Xbim.InformationSpecifications.NewTests/Constraints/ValueContraintTests.cs
+++ b/Xbim.InformationSpecifications.NewTests/Constraints/ValueContraintTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using System;
 using Xunit;
 
 namespace Xbim.InformationSpecifications.Tests
@@ -90,6 +91,60 @@ namespace Xbim.InformationSpecifications.Tests
             vc.IsSatisfiedBy(42.3d).Should().BeFalse();
         }
 
+        [Fact]
+        public void LongValueTypeIsInferred()
+        {
+            // from IDS test    property\pass-integer_values_are_checked_using_type_casting_1_4.ifc
+            // and              attribute\pass-integers_follow_the_same_rules_as_numbers.ids
+            ValueConstraint vc = new ValueConstraint(42);
+            vc.BaseType = NetTypeName.Undefined;    // E.g. on Attribute values we won't have a BaseType on a simpleValue constraint
+            vc.IsSatisfiedBy(42L).Should().BeTrue("42==42");
+        }
+
+        [Fact]
+        public void IntValueTypeIsInferred()
+        {
+            ValueConstraint vc = new ValueConstraint(42);
+            vc.BaseType = NetTypeName.Undefined;
+            vc.IsSatisfiedBy(42).Should().BeTrue("42==42");
+
+        }
+
+        [Fact]
+        public void DecimalValueTypeIsInferred()
+        {
+            ValueConstraint vc = new ValueConstraint(42m);
+            vc.BaseType = NetTypeName.Undefined;
+            vc.IsSatisfiedBy(42m).Should().BeTrue("42m==42m");
+        }
+
+        [Fact]
+        public void FloatValueTypeIsInferred()
+        {
+            ValueConstraint vc = new ValueConstraint(42f);
+            vc.BaseType = NetTypeName.Undefined;
+            vc.IsSatisfiedBy(42d).Should().BeTrue("42f==42d");
+
+        }
+
+        [Fact]
+        public void DoubleValueTypeIsInferred()
+        {
+            ValueConstraint vc = new ValueConstraint(42d);
+            vc.BaseType = NetTypeName.Undefined;
+            vc.IsSatisfiedBy(42f).Should().BeTrue("42d==42f");
+
+        }
+
+        // For Completeness
+        [Fact]
+        public void TimeSpanValueTypeIsInferred()
+        {
+            ValueConstraint vc = new ValueConstraint(TimeSpan.FromDays(42).ToString());
+            vc.BaseType = NetTypeName.Undefined;
+            vc.IsSatisfiedBy(TimeSpan.FromDays(42)).Should().BeTrue("42==42");
+
+        }
 
         [Fact]
         public void CaseSensitiviyTests()

--- a/Xbim.InformationSpecifications.NewTests/Constraints/ValueContraintTests.cs
+++ b/Xbim.InformationSpecifications.NewTests/Constraints/ValueContraintTests.cs
@@ -321,6 +321,24 @@ namespace Xbim.InformationSpecifications.Tests
             // 41.999958d satisfies being in the range 42-50 inclusive, but also satisfies being < 42 exclusive
         }
 
+        [InlineData(1.2345678919873e-22d)]    // Not Supported as we Round to 6 DP
+        [InlineData(1.2345678919873e-6d)]
+        [InlineData(1.2345678919873e22d)]
+        [InlineData(1234567891.9873d)]
+        [InlineData(0d)]
+        [InlineData(-1d)]
+        [InlineData(-1e-5d)]
+        [InlineData(-1e-6d)]
+        [InlineData(-1.2345678919873e22d)]
+        [Theory]
+        public void ExtremeRealValuesAreHandled(double value)
+        {
+            var vc = new ValueConstraint(value);
+
+            vc.IsSatisfiedBy(value).Should().BeTrue();
+
+        }
+
         [InlineData(NetTypeName.Decimal)]
         [InlineData(NetTypeName.Floating)]
         [InlineData(NetTypeName.Double)]

--- a/Xbim.InformationSpecifications/Values/ExactConstraint.cs
+++ b/Xbim.InformationSpecifications/Values/ExactConstraint.cs
@@ -120,8 +120,8 @@ namespace Xbim.InformationSpecifications
 
             return candidateValue switch
             {
-                float => IsEqualWithinTolerance(Convert.ToSingle(expectedValue), Convert.ToSingle(candidateValue)),
-                double => IsEqualWithinTolerance(Convert.ToDouble(expectedValue), Convert.ToDouble(candidateValue)),
+                float => ValueConstraint.IsEqualWithinTolerance(Convert.ToSingle(expectedValue), Convert.ToSingle(candidateValue)),
+                double => ValueConstraint.IsEqualWithinTolerance(Convert.ToDouble(expectedValue), Convert.ToDouble(candidateValue)),
                 // Use decimal as means to compare equality of integral numbers - boxed int 42 != long 42
                 int => Convert.ToDecimal(expectedValue) == Convert.ToDecimal(candidateValue),
                 short => Convert.ToDecimal(expectedValue) == Convert.ToDecimal(candidateValue),
@@ -134,21 +134,13 @@ namespace Xbim.InformationSpecifications
         {
             return candidateValue switch
             {
-                float => IsEqualWithinTolerance(Convert.ToSingle(Value), Convert.ToSingle(candidateValue)),
-                double => IsEqualWithinTolerance(Convert.ToDouble(Value), Convert.ToDouble(candidateValue)),
+                float =>  ValueConstraint.IsEqualWithinTolerance(Convert.ToSingle(Value), Convert.ToSingle(candidateValue)),
+                double => ValueConstraint.IsEqualWithinTolerance(Convert.ToDouble(Value), Convert.ToDouble(candidateValue)),
                 _ => false
             };
         }
 
 
-        const double DefaultPrecision = 1e-6;
-        private static bool IsEqualWithinTolerance(double expectedValue, double candidate, double tolerance = DefaultPrecision, int decimals = 6)
-        {
-            // Based on https://github.com/buildingSMART/IDS/issues/36#issuecomment-1014473533
-            var lowerBound = Math.Round(expectedValue * (1 - tolerance), decimals);
-            var upperBound = Math.Round(expectedValue * (1 + tolerance), decimals);
-
-            return candidate >= lowerBound && candidate <= upperBound;
-        }
+        
     }
 }

--- a/Xbim.InformationSpecifications/Values/ExactConstraint.cs
+++ b/Xbim.InformationSpecifications/Values/ExactConstraint.cs
@@ -25,18 +25,18 @@ namespace Xbim.InformationSpecifications
         public string Value { get; set; }
 
         /// <inheritdoc />
-        public bool IsSatisfiedBy(object candiatateValue, ValueConstraint context, bool ignoreCase, ILogger? logger = null)
+        public bool IsSatisfiedBy(object candidateValue, ValueConstraint context, bool ignoreCase, ILogger? logger = null)
         {
             if (context.BaseType == NetTypeName.Undefined && !ignoreCase)
             {
                 // if we are comparing without a type constraint, we match the type of the 
                 // candidate, rather than converting all to string.
-                var toCheck = ValueConstraint.CastObject(Value, candiatateValue);
-                return ValueConstraint.FormalEquals(candiatateValue, toCheck);
+                var toCheck = ValueConstraint.ParseValue(Value, candidateValue);
+                return ValueConstraint.FormalEquals(candidateValue, toCheck);
             }
             if (ignoreCase)
-                return Value.Equals(candiatateValue.ToString(), comparisonType: StringComparison.OrdinalIgnoreCase);
-            return Value.Equals(candiatateValue.ToString());
+                return Value.Equals(candidateValue.ToString(), comparisonType: StringComparison.OrdinalIgnoreCase);
+            return Value.Equals(candidateValue.ToString());
         }
 
         /// <inheritdoc />
@@ -79,7 +79,7 @@ namespace Xbim.InformationSpecifications
         /// <inheritdoc />
         public bool IsValid(ValueConstraint context)
         {
-            var v = ValueConstraint.GetObject(Value, context.BaseType);
+            var v = ValueConstraint.ParseValue(Value, context.BaseType);
             // values need to be succesfully converted
             if (v is null && !string.IsNullOrEmpty(Value))
                 return false;

--- a/Xbim.InformationSpecifications/Values/IValueConstraintComponent.cs
+++ b/Xbim.InformationSpecifications/Values/IValueConstraintComponent.cs
@@ -12,7 +12,7 @@ namespace Xbim.InformationSpecifications
         /// </summary>
         /// <param name="candidateValue">the value to check</param>
         /// <param name="context">The parent constraint, not itself implementing <see cref="IValueConstraintComponent"/></param>
-        /// <param name="ignoreCase">In case of evaluation of strings, defines if the letter case should be considered or ignored, true to ignore.</param>
+        /// <param name="ignoreCase">When <c>true</c> any strings will be compared case insensitively ignoring accents; otherwise if <c>false</c> an exact match is required.</param>
         /// <param name="logger">logging context</param>
         /// <returns>true if satisfied by the value</returns>
         bool IsSatisfiedBy(object candidateValue, ValueConstraint context, bool ignoreCase, ILogger? logger = null);

--- a/Xbim.InformationSpecifications/Values/IValueConstraintComponent.cs
+++ b/Xbim.InformationSpecifications/Values/IValueConstraintComponent.cs
@@ -8,14 +8,14 @@ namespace Xbim.InformationSpecifications
     public interface IValueConstraintComponent
     {
         /// <summary>
-        /// Evaluates the constraint of the given <paramref name="candiatateValue"/>
+        /// Evaluates the constraint of the given <paramref name="candidateValue"/>
         /// </summary>
-        /// <param name="candiatateValue">the value to check</param>
+        /// <param name="candidateValue">the value to check</param>
         /// <param name="context">The parent constraint, not itself implementing <see cref="IValueConstraintComponent"/></param>
         /// <param name="ignoreCase">In case of evaluation of strings, defines if the letter case should be considered or ignored, true to ignore.</param>
         /// <param name="logger">logging context</param>
         /// <returns>true if satisfied by the value</returns>
-        bool IsSatisfiedBy(object candiatateValue, ValueConstraint context, bool ignoreCase, ILogger? logger = null);
+        bool IsSatisfiedBy(object candidateValue, ValueConstraint context, bool ignoreCase, ILogger? logger = null);
         
         /// <summary>
         /// a brief description of the component

--- a/Xbim.InformationSpecifications/Values/PatternConstraint.cs
+++ b/Xbim.InformationSpecifications/Values/PatternConstraint.cs
@@ -112,7 +112,7 @@ namespace Xbim.InformationSpecifications
         }
 
         /// <inheritdoc />
-        public bool IsSatisfiedBy(object candiatateValue, ValueConstraint context, bool ignoreCase, ILogger? logger = null)
+        public bool IsSatisfiedBy(object candidateValue, ValueConstraint context, bool ignoreCase, ILogger? logger = null)
         {
             if (ignoreCase)
             {
@@ -123,7 +123,7 @@ namespace Xbim.InformationSpecifications
                     logger?.LogError("CaseInsensitiveRegex was unexpectedly null for pattern {pattern}.", pattern);
                     return false;
                 }
-                var str = candiatateValue.ToString();
+                var str = candidateValue.ToString();
                 if (str is null)
                     return false;
                 return compiledCaseInsensitiveRegex.IsMatch(str);
@@ -137,7 +137,7 @@ namespace Xbim.InformationSpecifications
                     logger?.LogError("CaseSensitiveRegex was unexpectedly null for pattern {pattern}.", pattern);
                     return false;
                 }
-                var str = candiatateValue.ToString();
+                var str = candidateValue.ToString();
                 if (str is null)
                     return false;
                 return compiledCaseSensitiveRegex.IsMatch(str);

--- a/Xbim.InformationSpecifications/Values/RangeConstraint.cs
+++ b/Xbim.InformationSpecifications/Values/RangeConstraint.cs
@@ -84,27 +84,27 @@ namespace Xbim.InformationSpecifications
         }
 
         /// <inheritdoc />
-        public bool IsSatisfiedBy(object candiatateValue, ValueConstraint context, bool ignoreCase, ILogger? logger = null)
+        public bool IsSatisfiedBy(object candidateValue, ValueConstraint context, bool ignoreCase, ILogger? logger = null)
         {
             if (context is null)
                 return false;
-            if (candiatateValue is not IComparable compe)
+            if (candidateValue is not IComparable compe)
             {
-                logger?.LogError("Failed to create a comparable value from {candidateValueType} '{candiatateValue}'", candiatateValue.GetType().Name, candiatateValue);
+                logger?.LogError("Failed to create a comparable value from {candidateValueType} '{candidateValue}'", candidateValue.GetType().Name, candidateValue);
                 return false;
             }
             var minOk = true;
             var maxOk = true;
             if (MinValue is not null && !string.IsNullOrEmpty(MinValue))
             {
-                var mn = ValueConstraint.GetObject(MinValue, context.BaseType);
+                var mn = ValueConstraint.ParseValue(MinValue, context.BaseType);
                 minOk = MinInclusive
                     ? compe.CompareTo(mn) >= 0
                     : compe.CompareTo(mn) > 0;
             }
             if (MaxValue is not null && !string.IsNullOrEmpty(MaxValue))
             {
-                var mx = ValueConstraint.GetObject(MaxValue, context.BaseType);
+                var mx = ValueConstraint.ParseValue(MaxValue, context.BaseType);
                 maxOk = MaxInclusive
                     ? compe.CompareTo(mx) <= 0
                     : compe.CompareTo(mx) < 0;
@@ -132,8 +132,8 @@ namespace Xbim.InformationSpecifications
         /// <inheritdoc />
         public bool IsValid(ValueConstraint context)
         {
-            var min = ValueConstraint.GetObject(MinValue, context.BaseType);
-            var max = ValueConstraint.GetObject(MaxValue, context.BaseType);
+            var min = ValueConstraint.ParseValue(MinValue, context.BaseType);
+            var max = ValueConstraint.ParseValue(MaxValue, context.BaseType);
 
             // values need to be succesfully converted
             if (min is null && !string.IsNullOrEmpty(MinValue))

--- a/Xbim.InformationSpecifications/Values/StructureConstraint.cs
+++ b/Xbim.InformationSpecifications/Values/StructureConstraint.cs
@@ -181,25 +181,25 @@ namespace Xbim.InformationSpecifications
         }
 
         /// <inheritdoc />
-        public bool IsSatisfiedBy(object? candiatateValue, ValueConstraint context, bool ignoreCase, ILogger? logger = null)
+        public bool IsSatisfiedBy(object? candidateValue, ValueConstraint context, bool ignoreCase, ILogger? logger = null)
         {
             if (TotalDigits.HasValue)
             {
-                if (candiatateValue is null)
+                if (candidateValue is null)
                     return false;
                 // first of all, if candidateValue is float or double we convert it to decimal to count the digits.
-                switch (candiatateValue)
+                switch (candidateValue)
                 {
                     case float f:
                         // todo: should there be a warning for conversion here?
-                        candiatateValue = Convert.ToDecimal(f);
+                        candidateValue = Convert.ToDecimal(f);
                         break;
                     case double d:
                         // todo: should there be a warning for conversion here?
-                        candiatateValue = Convert.ToDecimal(d);
+                        candidateValue = Convert.ToDecimal(d);
                         break;
                 }
-                switch (candiatateValue)
+                switch (candidateValue)
                 {
                     case decimal dec:
                         {
@@ -223,25 +223,25 @@ namespace Xbim.InformationSpecifications
                             break;
                         }
                     default:
-                        logger?.LogError("TotalDigits check is not implemented for type '{}'", candiatateValue.GetType().Name);
+                        logger?.LogError("TotalDigits check is not implemented for type '{}'", candidateValue.GetType().Name);
                         return false;
                 }
             }
             if (FractionDigits.HasValue)
             {
-                if (candiatateValue is null)
+                if (candidateValue is null)
                     return false;
                 // first of all, if candidateValue is float or double we convert it to decimal to count the digits.
-                switch (candiatateValue)
+                switch (candidateValue)
                 {
                     case float f:
-                        candiatateValue = Convert.ToDecimal(f);
+                        candidateValue = Convert.ToDecimal(f);
                         break;
                     case double d:
-                        candiatateValue = Convert.ToDecimal(d);
+                        candidateValue = Convert.ToDecimal(d);
                         break;
                 }
-                switch (candiatateValue)
+                switch (candidateValue)
                 {
                     case decimal dec:
                         {
@@ -257,15 +257,15 @@ namespace Xbim.InformationSpecifications
                             return false;
                         break;
                     default:
-                        logger?.LogError("TotalDigits check is not implemented for type '{}'", candiatateValue.GetType().Name);
+                        logger?.LogError("TotalDigits check is not implemented for type '{}'", candidateValue.GetType().Name);
                         return false;
                 }
             }
             if (Length.HasValue || MinLength.HasValue || MaxLength.HasValue)
             {
-                if (candiatateValue is null)
+                if (candidateValue is null)
                     return false;
-                var eval = candiatateValue.ToString() ?? string.Empty;
+                var eval = candidateValue.ToString() ?? string.Empty;
                 var l = eval.Length;
                 if (Length.HasValue && l != Length.Value)
                     return false;

--- a/Xbim.InformationSpecifications/Values/TypeNames.cs
+++ b/Xbim.InformationSpecifications/Values/TypeNames.cs
@@ -203,6 +203,17 @@ namespace Xbim.InformationSpecifications
 			maxInclusive,
         }
 
+        /// <summary>
+        /// Converts the passed <paramref name="value"/> to the provided <paramref name="typeName"/>
+        /// </summary>
+        /// <param name="value">the value to try to convert</param>
+        /// <param name="typeName">the destination type</param>
+        /// <returns>Null when conversion is not successful</returns>
+        [Obsolete("Prefer ConvertObject()")]
+        public static object? GetObject(object value, NetTypeName typeName)
+        {
+            return ConvertObject(value, typeName);
+        }
 
         /// <summary>
         /// Converts the passed <paramref name="value"/> to the provided <paramref name="typeName"/>
@@ -210,38 +221,48 @@ namespace Xbim.InformationSpecifications
         /// <param name="value">the value to try to convert</param>
         /// <param name="typeName">the destination type</param>
         /// <returns>Null when conversion is not successful</returns>
-		public static object? GetObject(object value, NetTypeName typeName)
+		public static object? ConvertObject(object value, NetTypeName typeName)
         {
-            if (typeName == NetTypeName.Undefined) // if undefined type just return the value, unaltered.
-                return value;
-            if (typeName == NetTypeName.Integer)
-                return Convert.ToInt32(value);
-            if (typeName == NetTypeName.Decimal)
-                return Convert.ToDecimal(value);
-            if (typeName == NetTypeName.Double)
-                return Convert.ToDouble(value);
-            if (typeName == NetTypeName.Floating)
-                return Convert.ToSingle(value);
-            if (typeName == NetTypeName.Date)
-                return Convert.ToDateTime(value);
-            if (typeName == NetTypeName.Boolean)
-                return Convert.ToBoolean(value);
-            if (typeName == NetTypeName.Time)
+            switch (typeName) // if undefined type just return the value, unaltered.
             {
-                var tmp = Convert.ToDateTime(value);
-                return tmp.TimeOfDay;
+                case NetTypeName.Undefined:
+                    return value;
+                case NetTypeName.Integer:
+                    return Convert.ToInt32(value);
+                case NetTypeName.Decimal:
+                    return Convert.ToDecimal(value);
+                case NetTypeName.Double:
+                    return Convert.ToDouble(value);
+                case NetTypeName.Floating:
+                    return Convert.ToSingle(value);
+                case NetTypeName.Date:
+                case NetTypeName.DateTime:
+                    return Convert.ToDateTime(value);
+                case NetTypeName.Boolean:
+                    return Convert.ToBoolean(value);
+                case NetTypeName.Time:
+                    {
+                        var tmp = Convert.ToDateTime(value);
+                        return tmp.TimeOfDay;
+                    }
+
+                case NetTypeName.Uri:
+                    {
+                        if (Uri.TryCreate(value.ToString(), UriKind.RelativeOrAbsolute, out var val))
+                            return val;
+                        return null;
+                    }
+                case NetTypeName.Duration:
+                    if (TimeSpan.TryParse(value.ToString(), CultureInfo.InvariantCulture, out var duration))
+                        return duration;
+                    return null;
+
+                case NetTypeName.String:
+                    return value.ToString();
+                
+                default:
+                    return value;
             }
-            if (typeName == NetTypeName.Uri)
-            {
-                if (Uri.TryCreate(value.ToString(), UriKind.RelativeOrAbsolute, out var val))
-                    return val;
-                return null;
-            }
-            if (typeName == NetTypeName.String)
-            {
-                return value.ToString();
-            }
-            return value;
         }
 
         /// <summary>
@@ -250,27 +271,53 @@ namespace Xbim.InformationSpecifications
         /// <param name="value">The value to cast</param>
         /// <param name="castingObjectForType">An object used to determine the casting</param>
         /// <returns>a cast object according to the type of <paramref name="castingObjectForType"/></returns>
+        [Obsolete("Prefer ParseValue()")]
         public static object? CastObject(string value, object castingObjectForType)
         {
-            return castingObjectForType switch
+            return ParseValue(value, castingObjectForType);
+        }
+
+        /// <summary>
+        /// Parse the constraint value into a form suitable for the target type
+        /// </summary>
+        /// <param name="value">The value to cast</param>
+        /// <param name="targetType">An object used to determine the type to parse to</param>
+        /// <returns>a cast object according to the type of <paramref name="targetType"/></returns>
+        public static object? ParseValue(string value, object targetType)
+        {
+            return targetType switch
             {
-                // TODO: Decimal
-                double => GetObject(value, NetTypeName.Double),
-                float => GetObject(value, NetTypeName.Floating),
-                int => GetObject(value, NetTypeName.Integer),
-                DateTime => GetObject(value, NetTypeName.DateTime),
-                TimeSpan => GetObject(value, NetTypeName.Duration),
+                double => ParseValue(value, NetTypeName.Double),
+                float => ParseValue(value, NetTypeName.Floating),
+                decimal => ParseValue(value, NetTypeName.Decimal),
+                short => ParseValue(value, NetTypeName.Integer),
+                int => ParseValue(value, NetTypeName.Integer),
+                long => ParseValue(value, NetTypeName.Integer),
+                DateTime => ParseValue(value, NetTypeName.DateTime),
+                TimeSpan => ParseValue(value, NetTypeName.Duration),
                 _ => value,
             };
         }
 
         /// <summary>
-        /// Converts the passed string <paramref name="value"/> to the provided <paramref name="typeName"/>
+        /// Attempt to Parse the passed string <paramref name="value"/> to the provided <paramref name="typeName"/>
         /// </summary>
         /// <param name="value">The value to parse</param>
         /// <param name="typeName">The destination type required</param>
         /// <returns>Null if parsing or conversion are not succesful, a nullable string in case of undefined type</returns>
-		public static object? GetObject(string? value, NetTypeName typeName)
+        [Obsolete("Prefer ParseValue()")]
+        public static object? GetObject(string? value, NetTypeName typeName)
+        {
+            return ParseValue(value, typeName);
+        }
+
+        /// <summary>
+        /// Attempt to Parse the passed string <paramref name="value"/> to the provided <paramref name="typeName"/>
+        /// </summary>
+        /// <param name="value">The value to parse</param>
+        /// <param name="typeName">The destination type required</param>
+        /// <returns>Null if parsing or conversion are not succesful, a nullable string in case of undefined type</returns>
+		public static object? ParseValue(string? value, NetTypeName typeName)
         {
             var culture = CultureHelper.SystemCulture;
             if (string.IsNullOrEmpty(value))
@@ -286,7 +333,8 @@ namespace Xbim.InformationSpecifications
                 case NetTypeName.String:
                     return value;
                 case NetTypeName.Integer:
-                    if (int.TryParse(value, NumberStyles.Integer, culture, out var ival))
+                    // Use decimal as a unifying type for all integral values
+                    if (decimal.TryParse(value, NumberStyles.Integer, culture, out var ival))
                         return ival;
                     return null;
                 case NetTypeName.Floating:
@@ -339,12 +387,20 @@ namespace Xbim.InformationSpecifications
             };
         }
 
-        internal static bool FormalEquals(object toCheck, object? candiatateValue)
+        internal static bool FormalEquals(object toCheck, object? candidateValue)
         {
             // special casts for ifcTypes
             if (toCheck.GetType().Name == "IfcGloballyUniqueId")
-                return toCheck.ToString()!.Equals(candiatateValue);   
-            return toCheck.Equals(candiatateValue);
+                return toCheck.ToString()!.Equals(candidateValue);
+
+            return toCheck switch
+            {
+                // Use decimal as means to compare equality of integral numbers - boxed int 42 != long 42
+                int => Convert.ToDecimal(toCheck) == Convert.ToDecimal(candidateValue),
+                short => Convert.ToDecimal(toCheck) == Convert.ToDecimal(candidateValue),
+                long => Convert.ToDecimal(toCheck) == Convert.ToDecimal(candidateValue),
+                _ => toCheck.Equals(candidateValue)
+            };
         }
     }
 }

--- a/Xbim.InformationSpecifications/Values/TypeNames.cs
+++ b/Xbim.InformationSpecifications/Values/TypeNames.cs
@@ -387,20 +387,5 @@ namespace Xbim.InformationSpecifications
             };
         }
 
-        internal static bool FormalEquals(object toCheck, object? candidateValue)
-        {
-            // special casts for ifcTypes
-            if (toCheck.GetType().Name == "IfcGloballyUniqueId")
-                return toCheck.ToString()!.Equals(candidateValue);
-
-            return toCheck switch
-            {
-                // Use decimal as means to compare equality of integral numbers - boxed int 42 != long 42
-                int => Convert.ToDecimal(toCheck) == Convert.ToDecimal(candidateValue),
-                short => Convert.ToDecimal(toCheck) == Convert.ToDecimal(candidateValue),
-                long => Convert.ToDecimal(toCheck) == Convert.ToDecimal(candidateValue),
-                _ => toCheck.Equals(candidateValue)
-            };
-        }
     }
 }

--- a/Xbim.InformationSpecifications/Values/TypeNames.cs
+++ b/Xbim.InformationSpecifications/Values/TypeNames.cs
@@ -228,21 +228,21 @@ namespace Xbim.InformationSpecifications
                 case NetTypeName.Undefined:
                     return value;
                 case NetTypeName.Integer:
-                    return Convert.ToInt32(value);
+                    return Convert.ToInt32(value, CultureHelper.SystemCulture);
                 case NetTypeName.Decimal:
-                    return Convert.ToDecimal(value);
+                    return Convert.ToDecimal(value, CultureHelper.SystemCulture);
                 case NetTypeName.Double:
-                    return Convert.ToDouble(value);
+                    return Convert.ToDouble(value, CultureHelper.SystemCulture);
                 case NetTypeName.Floating:
-                    return Convert.ToSingle(value);
+                    return Convert.ToSingle(value, CultureHelper.SystemCulture);
                 case NetTypeName.Date:
                 case NetTypeName.DateTime:
-                    return Convert.ToDateTime(value);
+                    return Convert.ToDateTime(value, CultureHelper.SystemCulture);
                 case NetTypeName.Boolean:
                     return Convert.ToBoolean(value);
                 case NetTypeName.Time:
                     {
-                        var tmp = Convert.ToDateTime(value);
+                        var tmp = Convert.ToDateTime(value, CultureHelper.SystemCulture);
                         return tmp.TimeOfDay;
                     }
 

--- a/Xbim.InformationSpecifications/Values/ValueConstraint.cs
+++ b/Xbim.InformationSpecifications/Values/ValueConstraint.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Xbim.InformationSpecifications.Helpers;
 
 namespace Xbim.InformationSpecifications
 {
@@ -88,7 +89,7 @@ namespace Xbim.InformationSpecifications
         }
 
         /// <summary>
-        /// Evaluates a candidate value, against the constraints, where strings are compared case sensitively
+        /// Evaluates a candidate value, against the constraints, where strings are compared case-sensitively
         /// </summary>
         /// <param name="candidateValue">value to evaluate</param>
         /// <param name="logger">the logging context</param>
@@ -99,7 +100,7 @@ namespace Xbim.InformationSpecifications
         }
 
         /// <summary>
-        /// Evaluates a candidate value, against the constraints, strings are compared with ignoring case match
+        /// Evaluates a candidate value against the constraints, where strings are compared case-insensitively
         /// </summary>
         /// <param name="candidateValue">value to evaluate</param>
         /// <param name="logger">the logging context</param>
@@ -194,7 +195,7 @@ namespace Xbim.InformationSpecifications
         {
             AcceptedValues = new List<IValueConstraintComponent>
             {
-                new ExactConstraint(value.ToString())
+                new ExactConstraint(value.ToString(CultureHelper.SystemCulture))
             };
             BaseType = NetTypeName.Integer;
         }
@@ -207,7 +208,7 @@ namespace Xbim.InformationSpecifications
         {
             AcceptedValues = new List<IValueConstraintComponent>
             {
-                new ExactConstraint(value.ToString())
+                new ExactConstraint(value.ToString(CultureHelper.SystemCulture))
             };
             BaseType = NetTypeName.Decimal;
         }
@@ -220,7 +221,7 @@ namespace Xbim.InformationSpecifications
         {
             AcceptedValues = new List<IValueConstraintComponent>
             {
-                new ExactConstraint(value.ToString())
+                new ExactConstraint(value.ToString(CultureHelper.SystemCulture))
             };
             BaseType = NetTypeName.Double;
         }
@@ -422,7 +423,7 @@ namespace Xbim.InformationSpecifications
                 exact = null;
                 return false;
             }
-            exact = unique.Value.ToString();
+            exact = unique.Value.ToString(CultureHelper.SystemCulture);
             return true;
         }
 

--- a/Xbim.InformationSpecifications/Values/ValueConstraint.cs
+++ b/Xbim.InformationSpecifications/Values/ValueConstraint.cs
@@ -62,7 +62,7 @@ namespace Xbim.InformationSpecifications
         /// Evaluates a candidate value, against the constraints
         /// </summary>
         /// <param name="candidateValue">value to evaluate</param>
-        /// <param name="ignoreCase">used for strings</param>
+        /// <param name="ignoreCase">when <c>true</c> ignore case and accents; otherwise when <c>false</c> tests for exact match</param>
         /// <param name="logger">logging context</param>
         /// <returns>true if satisfied, false otherwise</returns>
         public bool IsSatisfiedBy([NotNullWhen(true)] object? candidateValue, bool ignoreCase, ILogger? logger = null)
@@ -74,13 +74,13 @@ namespace Xbim.InformationSpecifications
             // if there are no constraints it's satisfied by default // todo: should this be revised?
             if (AcceptedValues == null || !AcceptedValues.Any())
                 return true;
-            var cand = ConvertObject(candidateValue, BaseType);
-            if (cand is null)
+            var candidateObject = ConvertObject(candidateValue, BaseType);
+            if (candidateObject is null)
                 return false;
 
             foreach (var av in AcceptedValues)
             {
-                if (av.IsSatisfiedBy(cand, this, ignoreCase, logger))
+                if (av.IsSatisfiedBy(candidateObject, this, ignoreCase, logger))
                     return true;
             }
             
@@ -88,7 +88,7 @@ namespace Xbim.InformationSpecifications
         }
 
         /// <summary>
-        /// Evaluates a candidate value, against the constraints, strings are compared with exact case match
+        /// Evaluates a candidate value, against the constraints, where strings are compared case sensitively
         /// </summary>
         /// <param name="candidateValue">value to evaluate</param>
         /// <param name="logger">the logging context</param>

--- a/Xbim.InformationSpecifications/Values/ValueConstraint.cs
+++ b/Xbim.InformationSpecifications/Values/ValueConstraint.cs
@@ -61,20 +61,20 @@ namespace Xbim.InformationSpecifications
         /// <summary>
         /// Evaluates a candidate value, against the constraints
         /// </summary>
-        /// <param name="candiatateValue">value to evaluate</param>
+        /// <param name="candidateValue">value to evaluate</param>
         /// <param name="ignoreCase">used for strings</param>
         /// <param name="logger">logging context</param>
         /// <returns>true if satisfied, false otherwise</returns>
-        public bool IsSatisfiedBy([NotNullWhen(true)] object? candiatateValue, bool ignoreCase, ILogger? logger = null)
+        public bool IsSatisfiedBy([NotNullWhen(true)] object? candidateValue, bool ignoreCase, ILogger? logger = null)
         {
-            if (candiatateValue is null)
+            if (candidateValue is null)
                 return false;
-            if (BaseType != NetTypeName.Undefined && !IsCompatible(ResolvedType(BaseType), candiatateValue.GetType()))
+            if (BaseType != NetTypeName.Undefined && !IsCompatible(ResolvedType(BaseType), candidateValue.GetType()))
                 return false;
             // if there are no constraints it's satisfied by default // todo: should this be revised?
             if (AcceptedValues == null || !AcceptedValues.Any())
                 return true;
-            var cand = GetObject(candiatateValue, BaseType);
+            var cand = ConvertObject(candidateValue, BaseType);
             if (cand is null)
                 return false;
 
@@ -90,23 +90,23 @@ namespace Xbim.InformationSpecifications
         /// <summary>
         /// Evaluates a candidate value, against the constraints, strings are compared with exact case match
         /// </summary>
-        /// <param name="candiatateValue">value to evaluate</param>
+        /// <param name="candidateValue">value to evaluate</param>
         /// <param name="logger">the logging context</param>
         /// <returns>true if satisfied, false otherwise</returns>
-        public bool IsSatisfiedBy([NotNullWhen(true)] object? candiatateValue, ILogger? logger = null)
+        public bool IsSatisfiedBy([NotNullWhen(true)] object? candidateValue, ILogger? logger = null)
         {
-            return IsSatisfiedBy(candiatateValue, false, logger);
+            return IsSatisfiedBy(candidateValue, false, logger);
         }
 
         /// <summary>
         /// Evaluates a candidate value, against the constraints, strings are compared with ignoring case match
         /// </summary>
-        /// <param name="candiatateValue">value to evaluate</param>
+        /// <param name="candidateValue">value to evaluate</param>
         /// <param name="logger">the logging context</param>
         /// <returns>true if satisfied, false otherwise</returns>
-        public bool IsSatisfiedIgnoringCaseBy([NotNullWhen(true)] object? candiatateValue, ILogger? logger = null)
+        public bool IsSatisfiedIgnoringCaseBy([NotNullWhen(true)] object? candidateValue, ILogger? logger = null)
         {
-            return IsSatisfiedBy(candiatateValue, true, logger);
+            return IsSatisfiedBy(candidateValue, true, logger);
         }
 
         static private bool IsCompatible([NotNullWhen(true)] Type? destType, Type passedType)
@@ -493,7 +493,7 @@ namespace Xbim.InformationSpecifications
                 return false;
             if (val is null)
                 return false;
-            var vbt = GetObject(val, BaseType);
+            var vbt = ConvertObject(val, BaseType);
             if (vbt is RequiredType exactAs)
             {
                 exact = exactAs;

--- a/Xbim.InformationSpecifications/Values/ValueConstraint.cs
+++ b/Xbim.InformationSpecifications/Values/ValueConstraint.cs
@@ -539,5 +539,26 @@ namespace Xbim.InformationSpecifications
             }
             return true;
         }
+
+        /// <summary>
+        /// The Default precision to use for Real equality testing
+        /// </summary>
+        internal const double DefaultRealPrecision = 1e-6;
+        /// <summary>
+        /// Determines if a Real value is equal to the expected value accounting for floating point tolerances
+        /// </summary>
+        /// <param name="expectedValue">The precise double value expected</param>
+        /// <param name="candidate">The candidate double value which may have FP imprecisions</param>
+        /// <param name="tolerance">The double tolerance. Defaults to 0.0000001</param>
+        /// <param name="decimals">The number of decimals to round to</param>
+        /// <returns></returns>
+        internal static bool IsEqualWithinTolerance(double expectedValue, double candidate, double tolerance = DefaultRealPrecision, int decimals = 6)
+        {
+            // Based on https://github.com/buildingSMART/IDS/issues/36#issuecomment-1014473533
+            var lowerBound = Math.Round(expectedValue * (1 - tolerance), decimals);
+            var upperBound = Math.Round(expectedValue * (1 + tolerance), decimals);
+
+            return candidate >= lowerBound && candidate <= upperBound;
+        }
     }
 }


### PR DESCRIPTION
1. When BaseType is undefined for `ExactConstraint` the `(int)42 == (long)42` would fail despite obvious implicit casting available if types were known.
BaseType is often undefined. E.g. Attributes don't have a `datatype` in the XSD in the same way Psets can
2. Minor tidying of some typos, and improved naming of some functions
3. Added support for treating accented strings as equal when using `ignoreCase = true`. E.g. "à rénover"=="A Renover"
ignoreCase is clearly an extension to the standard, but this feels like a useful addition.
4. Added support for ie-6 tolerance on Reals when testing equality with ExactConstraint. So 42 == 42.000042d, but 42 != 42.000084d
This is based on the algorithm at https://github.com/buildingSMART/IDS/issues/78#issuecomment-1594479489
5. Extended the ie-6 to RangeConstraints
This last one may need some discussion with other implementors as it introduces some subtleties, such as

42.00001 <= 42 : Constraint Satisfied - despite being > 42
42.00001 > 42 : Constraint Satisfied - as expected
 