### PR TITLE
IDS Specification ID persistance

### DIFF
--- a/Xbim.InformationSpecifications.NewTests/buildingSmartCompatibility.cs
+++ b/Xbim.InformationSpecifications.NewTests/buildingSmartCompatibility.cs
@@ -167,6 +167,35 @@ namespace Xbim.InformationSpecifications.Tests
         }
 
         [Fact]
+        public void CanRoundtripSpecificationIdentifier()
+        {
+            var id = Guid.NewGuid().ToString();
+            var x = new Xids();
+            // at least one specification is needed
+            //
+            var t = x.PrepareSpecification(IfcSchemaVersion.IFC2X3);
+            t.Requirement!.Facets.Add(new IfcTypeFacet() { IfcType = "IFCWALL" });
+            t.Applicability.Facets.Add(new IfcTypeFacet() { IfcType = "IFCWALL" });
+            t.Instructions = "Some instructions";
+            t.Guid = id;
+
+            // export
+            var tmpFile = Path.GetTempFileName();
+            x.ExportBuildingSmartIDS(tmpFile);
+
+            // check schema is valid with the identifier persisted
+            var c = Validate(tmpFile, GetXunitLogger());
+            c.Should().Be(Audit.Status.Ok);
+
+            var round = LoadBuildingSmartIDS(tmpFile);
+            var roundSpec = round?.SpecificationsGroups.FirstOrDefault()?.Specifications?.FirstOrDefault();
+            roundSpec.Should().NotBeNull();
+            roundSpec!.Guid.Should().Be(id);
+
+            File.Delete(tmpFile);
+        }
+
+        [Fact]
         public void DoubleFileExportTest()
         {
             Xids x = new();

--- a/Xbim.InformationSpecifications/IO/Xids.Io.xml.cs
+++ b/Xbim.InformationSpecifications/IO/Xids.Io.xml.cs
@@ -186,8 +186,11 @@ namespace Xbim.InformationSpecifications
             // instructions
             if (spec.Instructions != null)
                 xmlWriter.WriteAttributeString("instructions", spec.Instructions);
+            // identifier
+            if (spec.Guid != null)
+                xmlWriter.WriteAttributeString("identifier", spec.Guid);
 
-            
+
 
             // applicability
             xmlWriter.WriteStartElement("applicability", IdsNamespace);
@@ -767,6 +770,9 @@ namespace Xbim.InformationSpecifications
                         break;
                     case "instructions":
                         ret.Instructions = attribute.Value;
+                        break;
+                    case "identifier":
+                        ret.Guid = attribute.Value;
                         break;
                     default:
                         LogUnexpected(attribute, specificationElement, logger);

--- a/Xbim.InformationSpecifications/Xbim.InformationSpecifications.csproj
+++ b/Xbim.InformationSpecifications/Xbim.InformationSpecifications.csproj
@@ -19,7 +19,7 @@
 		<AssemblyName>Xbim.InformationSpecifications</AssemblyName>
 		<RootNamespace>Xbim.InformationSpecifications</RootNamespace>
 		<!-- Remember to update the hardcoded AssemblyVersion property in XIDS-->
-		<AssemblyVersion>1.0.3</AssemblyVersion>
+		<AssemblyVersion>1.0.4</AssemblyVersion>
 		<!-- Remember to update the hardcoded AssemblyVersion property in XIDS-->
 		<FileVersion>$(AssemblyVersion)</FileVersion>
 		<Version>$(AssemblyVersion)</Version>

--- a/Xbim.InformationSpecifications/Xids.AssemblyVersion.cs
+++ b/Xbim.InformationSpecifications/Xids.AssemblyVersion.cs
@@ -7,6 +7,6 @@
         /// This is useful for environments that do not allow to load information from the DLL dynamically
         /// (e.g. Blazor).
         /// </summary>
-        public static string AssemblyVersion => "1.0.3";
+        public static string AssemblyVersion => "1.0.4";
     }
 }


### PR DESCRIPTION
IDS Specification has an optional attribute 'identifier' but this was not persisted in buildingSMART XML. Added a test to verify the schema compliance as well as the round-tripping of the value.