### PR TITLE
Long enumeration lists can now be truncated to avoid excessively long facet descriptions.

### DIFF
--- a/Xbim.InformationSpecifications.NewTests/DescriptionTests/AttributeFacetDescriptionTests.cs
+++ b/Xbim.InformationSpecifications.NewTests/DescriptionTests/AttributeFacetDescriptionTests.cs
@@ -10,10 +10,10 @@ namespace Xbim.InformationSpecifications.Tests.DescriptionTests
 		[InlineData("FieldName", "123.*", "an attribute FieldName with value matching '123.*'", ConstraintType.Pattern)]
 		[InlineData("Easting", 56.78, "an attribute Easting with value 56.78")]
 		[InlineData("Name", null, "an attribute Name with value <any>")]
-		[InlineData("Status", "NOTSTARTED,STARTED,COMPLETED", "an attribute Status with value NOTSTARTED or STARTED or COMPLETED")]
-		[InlineData("Name,Description", null, "an attribute Name or Description with value <any>")]
-		[InlineData("Name,Description", "P.*", "an attribute Name or Description with value matching 'P.*'", ConstraintType.Pattern)]
-		[InlineData("Name,Description", "Foo", "an attribute Name or Description with value Foo")]
+		[InlineData("Status", "NOTSTARTED,STARTED,COMPLETED", "an attribute Status with value 'NOTSTARTED' or 'STARTED' or 'COMPLETED'")]
+		[InlineData("Name,Description", null, "an attribute 'Name' or 'Description' with value <any>")]
+		[InlineData("Name,Description", "P.*", "an attribute 'Name' or 'Description' with value matching 'P.*'", ConstraintType.Pattern)]
+		[InlineData("Name,Description", "Foo", "an attribute 'Name' or 'Description' with value Foo")]
 		[Theory]
 		public void AttributeFacetsRequirementsDescribed(string attributeName, object? attributeValue, string expected,
 			ConstraintType valueConstraint = ConstraintType.Exact)
@@ -36,10 +36,10 @@ namespace Xbim.InformationSpecifications.Tests.DescriptionTests
 		[InlineData("FieldName", "123.*", "with attribute FieldName with value matching '123.*'", ConstraintType.Pattern)]
 		[InlineData("Easting", 56.78, "with attribute Easting with value 56.78")]
 		[InlineData("Name", null, "with attribute Name with value <any>")]
-		[InlineData("Status", "NOTSTARTED,STARTED,COMPLETED", "with attribute Status with value NOTSTARTED or STARTED or COMPLETED")]
-		[InlineData("Name,Description", null, "with attribute Name or Description with value <any>")]
-		[InlineData("Name,Description", "P.*", "with attribute Name or Description with value matching 'P.*'", ConstraintType.Pattern)]
-		[InlineData("Name,Description", "Foo", "with attribute Name or Description with value Foo")]
+		[InlineData("Status", "NOTSTARTED,STARTED,COMPLETED", "with attribute Status with value 'NOTSTARTED' or 'STARTED' or 'COMPLETED'")]
+		[InlineData("Name,Description", null, "with attribute 'Name' or 'Description' with value <any>")]
+		[InlineData("Name,Description", "P.*", "with attribute 'Name' or 'Description' with value matching 'P.*'", ConstraintType.Pattern)]
+		[InlineData("Name,Description", "Foo", "with attribute 'Name' or 'Description' with value Foo")]
 		[Theory]
 		public void AttributeFacetsApplicabilityDescribed(string attributeName, object? attributeValue, string expected,
 			ConstraintType valueConstraint = ConstraintType.Exact)

--- a/Xbim.InformationSpecifications.NewTests/DescriptionTests/ClassificationFacetDescriptionTests.cs
+++ b/Xbim.InformationSpecifications.NewTests/DescriptionTests/ClassificationFacetDescriptionTests.cs
@@ -12,8 +12,8 @@ namespace Xbim.InformationSpecifications.Tests.DescriptionTests
 		[InlineData("EF_25.*", "Uniclass.*", "a classification matching 'EF_25.*' from system matching 'Uniclass.*'", ConstraintType.Pattern, ConstraintType.Pattern)]
 
 		[InlineData("SS_20", null, "a classification SS_20 from system <any>")]
-		[InlineData("EF_25,EF_26", "Uniclass 2015", "a classification EF_25 or EF_26 from system Uniclass 2015")]
-		[InlineData("EF_25,EF_26", "Uniclass 2015,UniClass", "a classification EF_25 or EF_26 from system Uniclass 2015 or UniClass")]
+		[InlineData("EF_25,EF_26", "Uniclass 2015", "a classification 'EF_25' or 'EF_26' from system Uniclass 2015")]
+		[InlineData("EF_25,EF_26", "Uniclass 2015,UniClass", "a classification 'EF_25' or 'EF_26' from system 'Uniclass 2015' or 'UniClass'")]
 		[Theory]
 		public void ClassificationFacetsRequirementsDescribed(string identifiers, string? systems, string expected,
 			ConstraintType identifierConstraint = ConstraintType.Exact, ConstraintType systemConstraint = ConstraintType.Exact)
@@ -33,8 +33,8 @@ namespace Xbim.InformationSpecifications.Tests.DescriptionTests
 		[InlineData("EF_25.*", "Uniclass.*", "with classification matching 'EF_25.*' from system matching 'Uniclass.*'", ConstraintType.Pattern, ConstraintType.Pattern)]
 
 		[InlineData("SS_20", null, "with classification SS_20 from system <any>")]
-		[InlineData("EF_25,EF_26", "Uniclass 2015", "with classification EF_25 or EF_26 from system Uniclass 2015")]
-		[InlineData("EF_25,EF_26", "Uniclass 2015,UniClass", "with classification EF_25 or EF_26 from system Uniclass 2015 or UniClass")]
+		[InlineData("EF_25,EF_26", "Uniclass 2015", "with classification 'EF_25' or 'EF_26' from system Uniclass 2015")]
+		[InlineData("EF_25,EF_26", "Uniclass 2015,UniClass", "with classification 'EF_25' or 'EF_26' from system 'Uniclass 2015' or 'UniClass'")]
 		[Theory]
 		public void ClassificationFacetsApplicabilityDescribed(string identifiers, string? systems, string expected,
 			ConstraintType identifierConstraint = ConstraintType.Exact, ConstraintType systemConstraint = ConstraintType.Exact)
@@ -45,6 +45,26 @@ namespace Xbim.InformationSpecifications.Tests.DescriptionTests
 			facet = BuildFacetFromInputs(identifiers, systems ?? "", identifierConstraint, systemConstraint);
 
 
+			facet.ApplicabilityDescription.Should().Be(expected);
+		}
+
+
+		[Fact]
+		public void ClassificationFacetsApplicabilityNameSupportsMultiplePatterns()
+		{
+			IfcClassificationFacet facet = new()
+			{
+				ClassificationSystem = new ValueConstraint(NetTypeName.String),
+				Identification = new ValueConstraint(NetTypeName.String),
+			};
+
+			AddConstraint(facet.ClassificationSystem, ConstraintType.Pattern, "Uniclass.*");
+
+			AddConstraint(facet.Identification, ConstraintType.Pattern, "EF_.*");
+			AddConstraint(facet.Identification, ConstraintType.Pattern, "Pr_.*");
+
+			// Undesireable but fixing needs thought. Documenting the behaviour for now. E.g. the quoting of 'matching <foo>'
+			var expected = "with classification matching 'EF_.*' or matching 'Pr_.*' from system matching 'Uniclass.*'";
 			facet.ApplicabilityDescription.Should().Be(expected);
 		}
 

--- a/Xbim.InformationSpecifications.NewTests/DescriptionTests/DescriptionBrevityTests.cs
+++ b/Xbim.InformationSpecifications.NewTests/DescriptionTests/DescriptionBrevityTests.cs
@@ -1,0 +1,51 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Xbim.InformationSpecifications.Tests.DescriptionTests
+{
+	public class DescriptionBrevityTests
+	{
+		[Fact]
+		public void CanTruncateLongEnumerableListsInRequirements()
+		{
+			var fileName = "bsFiles/IDS_demo_BIM-basis-ILS.ids";
+
+			var loaded = Xids.LoadBuildingSmartIDS(fileName);
+
+			var spec = loaded!.AllSpecifications().Skip(1).First();
+
+			var facet = spec!.Requirement!.Facets[1];   // A long requirement enumeration
+
+			var description = facet.RequirementDescription;
+			description.Should().StartWith("an attribute Name with value '-10 kelder' or ");
+			description.Length.Should().BeLessThan(250);
+			description.Should().EndWith("or 41 others");
+		}
+
+		[Fact]
+		public void CanTruncateLongEnumerableListsInApplicability()
+		{
+			var fileName = "bsFiles/IDS_demo_BIM-basis-ILS.ids";
+
+			var loaded = Xids.LoadBuildingSmartIDS(fileName);
+
+			var spec = loaded!.AllSpecifications().Skip(2).First();
+
+			var facet = spec!.Applicability!.Facets[0];   // A long Applicability enumeration
+
+			var description = facet.ApplicabilityDescription;
+			description.Should().StartWith("of entity 'actuator' or 'airterminal' or ");
+			description.Length.Should().BeLessThan(250);
+			description.Should().EndWith("or 117 others and of predefined type <any>");
+		}
+	}
+}

--- a/Xbim.InformationSpecifications.NewTests/DescriptionTests/IfcTypeDescriptionTests.cs
+++ b/Xbim.InformationSpecifications.NewTests/DescriptionTests/IfcTypeDescriptionTests.cs
@@ -12,7 +12,7 @@ namespace Xbim.InformationSpecifications.Tests.DescriptionTests
 		[InlineData("IFCWALL", null, "of entity Wall and of predefined type <any>")]
 		[InlineData("IFCWALL", "", "of entity Wall and of predefined type <any>")]
 		[InlineData(null, null, "of entity <any> and of predefined type <any>")]
-		[InlineData("IFCWALL,IFCWALLSTANDARDCASE", null, "of entity Wall or Wallstandardcase and of predefined type <any>")]
+		[InlineData("IFCWALL,IFCWALLSTANDARDCASE", null, "of entity 'wall' or 'wallstandardcase' and of predefined type <any>")]
 
 		[Theory]
 		public void IfcTypeFacetsApplicabilityDescribed(string? ifcType, string? predefined, string expected,
@@ -25,7 +25,7 @@ namespace Xbim.InformationSpecifications.Tests.DescriptionTests
 		[InlineData("IFCWALL", "PARTITIONING", "an entity Wall and of predefined type Partitioning")]
 		[InlineData("IFCWALL", null, "an entity Wall and of predefined type <any>")]
 		[InlineData(null, null, "an entity <any> and of predefined type <any>")]
-		[InlineData("IFCWALL,IFCWALLSTANDARDCASE", null, "an entity Wall or Wallstandardcase and of predefined type <any>")]
+		[InlineData("IFCWALL,IFCWALLSTANDARDCASE", null, "an entity 'wall' or 'wallstandardcase' and of predefined type <any>")]
 
 		[Theory]
 		public void IfcTypeFacetsRequirementDescribed(string? ifcType, string? predefined, string expected,

--- a/Xbim.InformationSpecifications.NewTests/DescriptionTests/MaterialFacetDescriptionTests.cs
+++ b/Xbim.InformationSpecifications.NewTests/DescriptionTests/MaterialFacetDescriptionTests.cs
@@ -6,7 +6,7 @@ namespace Xbim.InformationSpecifications.Tests.DescriptionTests
 	public class MaterialFacetDescriptionTests : BaseDescriptionTests
 	{
 		[InlineData("Concrete", "a material Concrete")]
-		[InlineData("Concrete,Aggregate", "a material Concrete or Aggregate")]
+		[InlineData("Concrete,Aggregate", "a material 'Concrete' or 'Aggregate'")]
 		[InlineData("Concrete.*", "a material matching 'Concrete.*'", ConstraintType.Pattern)]
 		[Theory]
 		public void MaterialFacetsRequirementsDescribed(string materialName, string expected, ConstraintType valueConstraint = ConstraintType.Exact)
@@ -20,7 +20,7 @@ namespace Xbim.InformationSpecifications.Tests.DescriptionTests
 		}
 
 		[InlineData("Concrete", "of material Concrete")]
-		[InlineData("Concrete,Aggregate", "of material Concrete or Aggregate")]
+		[InlineData("Concrete,Aggregate", "of material 'Concrete' or 'Aggregate'")]
 		[InlineData("Concrete.*", "of material matching 'Concrete.*'", ConstraintType.Pattern)]
 		[Theory]
 		public void MaterialFacetsApplicabilityDescribed(string materialName, string expected, ConstraintType valueConstraint = ConstraintType.Exact)

--- a/Xbim.InformationSpecifications/IO/Xids.Io.xml.cs
+++ b/Xbim.InformationSpecifications/IO/Xids.Io.xml.cs
@@ -26,7 +26,7 @@ namespace Xbim.InformationSpecifications
 				{
 					Async = false
 				};
-				if (PrettyOutput)
+				if (Settings.PrettyOutput)
 				{
 					settings.Indent = true;
 					settings.IndentChars = "\t";
@@ -37,9 +37,19 @@ namespace Xbim.InformationSpecifications
 		}
 
 		/// <summary>
+		/// System level settings for Xids controlling some system-wide behaviours.
+		/// </summary>
+		public static XidsSettings Settings { get; } = new XidsSettings();
+
+		/// <summary>
 		/// Determines if the XML output should be indented for readability
 		/// </summary>
-		public static bool PrettyOutput { get; set; } = true;
+		[Obsolete("Use Xids.Settings.PrettyPrint instead")]
+		public static bool PrettyOutput
+		{
+			get => Settings.PrettyOutput;
+			set => Settings.PrettyOutput = value;
+		}
 
 		/// <summary>
 		/// When exporting to bS IDS, export files can be one of the formats in this enum.

--- a/Xbim.InformationSpecifications/Xbim.InformationSpecifications.csproj
+++ b/Xbim.InformationSpecifications/Xbim.InformationSpecifications.csproj
@@ -18,7 +18,7 @@
 		<AssemblyName>Xbim.InformationSpecifications</AssemblyName>
 		<RootNamespace>Xbim.InformationSpecifications</RootNamespace>
 		<!-- Remember to update the hardcoded AssemblyVersion property in XIDS-->
-		<AssemblyVersion>1.0.10</AssemblyVersion>
+		<AssemblyVersion>1.0.11</AssemblyVersion>
 		<!-- Remember to update the hardcoded AssemblyVersion property in XIDS-->
 		<FileVersion>$(AssemblyVersion)</FileVersion>
 		<Version>$(AssemblyVersion)</Version>

--- a/Xbim.InformationSpecifications/Xids.AssemblyVersion.cs
+++ b/Xbim.InformationSpecifications/Xids.AssemblyVersion.cs
@@ -7,6 +7,6 @@
 		/// This is useful for environments that do not allow to load information from the DLL dynamically
 		/// (e.g. Blazor).
 		/// </summary>
-		public static string AssemblyVersion => "1.0.10";
+		public static string AssemblyVersion => "1.0.11";
 	}
 }

--- a/Xbim.InformationSpecifications/XidsSettings.cs
+++ b/Xbim.InformationSpecifications/XidsSettings.cs
@@ -1,0 +1,19 @@
+﻿namespace Xbim.InformationSpecifications
+{
+	/// <summary>
+	/// Settings controlling system behaviour
+	/// </summary>
+	public class XidsSettings
+	{
+		/// <summary>
+		/// Determines if the XML output should be indented for readability. (Default: true)
+		/// </summary>
+		public bool PrettyOutput { get; set; } = true;
+
+		/// <summary>
+		/// Determine the maximum number of values to output when describing a Facet. (Default: truncate at 10)
+		/// </summary>
+		/// <remarks>Can be used to limit the description of facets with ValueConstraints comprised of very long enumeration lists</remarks>
+		public int MaximumConstraintEnumsToDescribe { get; set; } = 10;
+	}
+}


### PR DESCRIPTION
Was often the case with explicit classification identifiers, or long lists of IfcEntity types - that the description became unreasonably long. 
'Exact' values now quoted when an enumeration is used. e.g A or B => 'A' or 'B' 

Added static Settings concept to Xids to permit easy runtime config.