### PR TITLE
Extended equivalence testing so numerics formatted as string can be tested against numeric types.

### DIFF
--- a/Xbim.InformationSpecifications.NewTests/Facets/ValidityTests.cs
+++ b/Xbim.InformationSpecifications.NewTests/Facets/ValidityTests.cs
@@ -24,7 +24,7 @@ namespace Xbim.InformationSpecifications.Tests.Facets
 
 		[Theory]
 		[MemberData(nameof(GetValidConstraints))]
-		void Can_tell_valid_constrains(ValueConstraint constraint)
+		public void Can_tell_valid_constrains(ValueConstraint constraint)
 		{
 			constraint.IsValid().Should().BeTrue();
 		}

--- a/Xbim.InformationSpecifications/Xbim.InformationSpecifications.csproj
+++ b/Xbim.InformationSpecifications/Xbim.InformationSpecifications.csproj
@@ -18,7 +18,7 @@
 		<AssemblyName>Xbim.InformationSpecifications</AssemblyName>
 		<RootNamespace>Xbim.InformationSpecifications</RootNamespace>
 		<!-- Remember to update the hardcoded AssemblyVersion property in XIDS-->
-		<AssemblyVersion>1.0.11</AssemblyVersion>
+		<AssemblyVersion>1.0.12</AssemblyVersion>
 		<!-- Remember to update the hardcoded AssemblyVersion property in XIDS-->
 		<FileVersion>$(AssemblyVersion)</FileVersion>
 		<Version>$(AssemblyVersion)</Version>

--- a/Xbim.InformationSpecifications/Xids.AssemblyVersion.cs
+++ b/Xbim.InformationSpecifications/Xids.AssemblyVersion.cs
@@ -7,6 +7,6 @@
 		/// This is useful for environments that do not allow to load information from the DLL dynamically
 		/// (e.g. Blazor).
 		/// </summary>
-		public static string AssemblyVersion => "1.0.11";
+		public static string AssemblyVersion => "1.0.12";
 	}
 }


### PR DESCRIPTION

E.g. "1.0" satisfies ExactConstraint(1.0d)

Pending a review against the IDS test suite to see if this regresses anything.