### PR TITLE
fix: handling voids and fills relationship as defined in the IDS

### DIFF
--- a/Xbim.InformationSpecifications.NewTests/Facets/PartOfFacetTests.cs
+++ b/Xbim.InformationSpecifications.NewTests/Facets/PartOfFacetTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using Xbim.InformationSpecifications.Helpers;
 using Xunit;
 
 namespace Xbim.InformationSpecifications.Tests.Facets
@@ -31,7 +32,7 @@ namespace Xbim.InformationSpecifications.Tests.Facets
 		{
 			var f = new PartOfFacet()
 			{
-				EntityRelation = relation.ToString().ToUpperInvariant()
+				EntityRelation = EnumHelper.ToXmlEnumString(relation)
 			};
 
 			f.GetRelation().Should().Be(relation);

--- a/Xbim.InformationSpecifications.NewTests/bsFiles/IDS_door_in_wall.ids
+++ b/Xbim.InformationSpecifications.NewTests/bsFiles/IDS_door_in_wall.ids
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ids:ids xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd" xmlns:ids="http://standards.buildingsmart.org/IDS">
+	<ids:info>
+		<ids:title>Test: Door in the wall</ids:title>
+		<ids:copyright>CAS</ids:copyright>
+		<ids:version>0.0.1</ids:version>
+		<ids:description>Test: Door inthe wall</ids:description>
+		<ids:author>martin.cerny@xbim.cz</ids:author>
+		<ids:date>2026-03-24</ids:date>
+		<ids:purpose>IFC-SPF model verification</ids:purpose>
+		<ids:milestone>01</ids:milestone>
+	</ids:info>
+	<ids:specifications>
+		<ids:specification ifcVersion="IFC4" name="IfcDoor Should Have a IfcWall" description="IfcDoor Should Have a IfcWall" identifier="01">
+			<ids:applicability minOccurs="0" maxOccurs="unbounded">
+				<ids:entity>
+					<ids:name>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="IFCDOOR" />
+							<xs:enumeration value="IFCDOORSTANDARDCASE" />
+						</xs:restriction>
+					</ids:name>
+				</ids:entity>
+			</ids:applicability>
+			<ids:requirements>
+				<ids:partOf cardinality="required" relation="IFCRELVOIDSELEMENT IFCRELFILLSELEMENT">
+					<ids:entity>
+						<ids:name>
+							<xs:restriction base="xs:string">
+								<xs:enumeration value="IFCWALL" />
+							</xs:restriction>
+						</ids:name>
+					</ids:entity>
+				</ids:partOf>
+			</ids:requirements>
+		</ids:specification>
+	</ids:specifications>
+</ids:ids>

--- a/Xbim.InformationSpecifications.NewTests/buildingSmartIDSLoadTests.cs
+++ b/Xbim.InformationSpecifications.NewTests/buildingSmartIDSLoadTests.cs
@@ -74,6 +74,45 @@ namespace Xbim.InformationSpecifications.Tests
 			}
 		}
 
+		[Theory]
+		[InlineData("bsFiles/IDS_door_in_wall.ids")]
+		public void CanLoadRelVoidsFillsFacet(string fileName)
+		{
+			var outputFile = Path.Combine(Path.GetTempPath(), "out.ids");
+			outputFile = Path.GetTempFileName();
+			try
+			{
+				DirectoryInfo d = new(".");
+				Debug.WriteLine(d.FullName);
+				ILogger<BuildingSmartIDSLoadTests> logg = GetXunitLogger();
+				CheckSchema(fileName, logg);
+				var loggerMock = Substitute.For<ILogger<BuildingSmartIDSLoadTests>>();
+				var loaded = Xids.LoadBuildingSmartIDS(fileName, logg); // this sends the log to xunit context, for debug purposes.
+				loaded = Xids.LoadBuildingSmartIDS(fileName, loggerMock); // we load again with the moq to check for logging events
+				Assert.NotNull(loaded);
+
+				var partOf = loaded!.SpecificationsGroups!.Single()!.Specifications!.First()!.Requirement!.Facets.First() as PartOfFacet;
+				partOf!.GetRelation().Should().Be(PartOfFacet.PartOfRelation.IfcRelVoidsFillsElement, "it's the expected relation");
+
+				var errorAndWarnings = loggerMock.ReceivedCalls().Where(call => call.IsErrorType(true, true, false));
+				errorAndWarnings.Count().Should().Be(0, "mismatch with expected value");
+
+				partOf.SetRelation(PartOfFacet.PartOfRelation.IfcRelVoidsFillsElement);
+				loaded.ExportBuildingSmartIDS(outputFile);
+				CheckSchema(outputFile, logg);
+				var reloaded = Xids.LoadBuildingSmartIDS(outputFile);
+				Assert.NotNull(reloaded);
+			}
+			catch (Exception)
+			{
+				throw;
+			}
+			finally
+			{
+				File.Delete(outputFile);
+			}
+		}
+
 		private static void CheckSchema(string tmpFile, ILogger<BuildingSmartIDSLoadTests>? logg = null)
 		{
 			using var tmpStream = File.OpenRead(tmpFile);

--- a/Xbim.InformationSpecifications/Facets/buildingSMART/PartOfFacet.cs
+++ b/Xbim.InformationSpecifications/Facets/buildingSMART/PartOfFacet.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Xml.Serialization;
 using Xbim.InformationSpecifications.Facets.buildingSMART;
+using Xbim.InformationSpecifications.Helpers;
 
 namespace Xbim.InformationSpecifications
 {
@@ -22,27 +24,28 @@ namespace Xbim.InformationSpecifications
 			/// <summary>
 			/// A relation of type IfcRelAggregates
 			/// </summary>
+			[XmlEnum("IFCRELAGGREGATES")]
 			IfcRelAggregates,
 			/// <summary>
 			/// A relation of type IfcRelAssignsToGroup or IfcRelAssignsToGroupByFactor
 			/// </summary>
+			[XmlEnum("IFCRELASSIGNSTOGROUP")]
 			IfcRelAssignsToGroup,
 			/// <summary>
 			/// A relation of type IfcRelContainedInSpatialStructure
 			/// </summary>
+			[XmlEnum("IFCRELCONTAINEDINSPATIALSTRUCTURE")]
 			IfcRelContainedInSpatialStructure,
 			/// <summary>
 			/// A relation of type IfcRelNests
 			/// </summary>
+			[XmlEnum("IFCRELNESTS")]
 			IfcRelNests,
 			/// <summary>
-			/// A relation of type IfcRelVoidsElement
+			/// A relation of type IfcRelVoidsElement IfcRelFillsElement
 			/// </summary>
-			IfcRelVoidsElement,
-			/// <summary>
-			/// A relation of type IfcRelFillsElement
-			/// </summary>
-			IfcRelFillsElement
+			[XmlEnum("IFCRELVOIDSELEMENT IFCRELFILLSELEMENT")]
+			IfcRelVoidsFillsElement,
 		}
 
 		/// <summary>
@@ -188,7 +191,7 @@ namespace Xbim.InformationSpecifications
 		/// <returns></returns>
 		public PartOfRelation GetRelation()
 		{
-			if (Enum.TryParse<PartOfRelation>(EntityRelation, true, out var loc))
+			if (EnumHelper.TryParseFromXmlEnum<PartOfRelation>(EntityRelation, out var loc))
 			{
 				return loc;
 			}
@@ -203,7 +206,7 @@ namespace Xbim.InformationSpecifications
 			if (value == PartOfRelation.Undefined)
 				EntityRelation = string.Empty;
 			else
-				EntityRelation = value.ToString();
+				EntityRelation = EnumHelper.ToXmlEnumString(value);
 		}
 
 		/// <summary>

--- a/Xbim.InformationSpecifications/Helpers/EnumHelper.cs
+++ b/Xbim.InformationSpecifications/Helpers/EnumHelper.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using System.Xml.Serialization;
+
+namespace Xbim.InformationSpecifications.Helpers
+{
+	/// <summary>
+	/// Provides utility methods for converting between enum values and their XML string representations using the
+	/// XmlEnumAttribute.
+	/// </summary>
+	/// <remarks>This class is intended to simplify working with enums that use the XmlEnumAttribute for custom XML
+	/// serialization names. It supports parsing XML strings to enum values and retrieving the XML string representation
+	/// for a given enum value. All methods are static and thread-safe.</remarks>
+	public static class EnumHelper
+	{
+		/// <summary>
+		/// Parses a string value to its corresponding enumeration value, matching either the value of the XmlEnumAttribute or
+		/// the enum field name.
+		/// </summary>
+		/// <remarks>This method is useful when working with XML-serialized enums that use the XmlEnumAttribute to
+		/// specify custom string values. If no XmlEnumAttribute is present or matched, the method falls back to matching the
+		/// enum field name.</remarks>
+		/// <typeparam name="T">The enumeration type to parse the value into. Must be a struct and an Enum.</typeparam>
+		/// <param name="value">The string representation of the enumeration value. This can be either the value specified in the XmlEnumAttribute
+		/// or the name of the enum field.</param>
+		/// <returns>The enumeration value of type T that corresponds to the specified string.</returns>
+		/// <exception cref="ArgumentException">Thrown if the specified value does not match any XmlEnumAttribute value or enum field name in the target
+		/// enumeration type.</exception>
+		public static T ParseFromXmlEnum<T>(string value) where T : struct, Enum
+		{
+			var type = typeof(T);
+
+			foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.Static))
+			{
+				var attr = field.GetCustomAttribute<XmlEnumAttribute>();
+
+				if (attr != null && attr.Name == value)
+					return (T)field.GetValue(null)!;
+
+				// Optional fallback: match enum name
+				if (field.Name == value)
+					return (T)field.GetValue(null)!;
+			}
+
+			throw new ArgumentException($"Unknown value '{value}' for enum {type.Name}");
+		}
+
+		/// <summary>
+		/// Attempts to parse the specified string as a value of the specified enumeration type, matching either the field
+		/// name or the value of the XmlEnumAttribute, if present.
+		/// </summary>
+		/// <remarks>This method supports parsing both the standard enum field names and custom values defined by the
+		/// XmlEnumAttribute. It is case-sensitive and does not throw exceptions for invalid input.</remarks>
+		/// <typeparam name="T">The enumeration type to parse the value into. Must be a struct and an Enum.</typeparam>
+		/// <param name="value">The string representation of the enumeration value to parse. This can be either the name of the enum field or the
+		/// value specified in the XmlEnumAttribute.</param>
+		/// <param name="result">When this method returns, contains the parsed enumeration value if the parse operation succeeds; otherwise, the
+		/// default value for the type.</param>
+		/// <returns>true if the value was successfully parsed into the specified enumeration type; otherwise, false.</returns>
+		public static bool TryParseFromXmlEnum<T>(string value, out T result) where T : struct, Enum
+		{
+			var type = typeof(T);
+
+			foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.Static))
+			{
+				var attr = field.GetCustomAttribute<XmlEnumAttribute>();
+
+				if ((attr != null && attr.Name == value) || field.Name == value)
+				{
+					result = (T)field.GetValue(null)!;
+					return true;
+				}
+			}
+
+			result = default;
+			return false;
+		}
+
+		/// <summary>
+		/// Returns the XML representation of the specified enumeration value, using the value defined by the XmlEnumAttribute
+		/// if present.
+		/// </summary>
+		/// <remarks>This method is useful when serializing enumeration values to XML, ensuring that any custom names
+		/// specified by the XmlEnumAttribute are respected. If the enumeration value does not have an XmlEnumAttribute, the
+		/// method returns the standard name of the value.</remarks>
+		/// <typeparam name="T">The enumeration type whose value is to be converted.</typeparam>
+		/// <param name="value">The enumeration value to convert to its XML string representation.</param>
+		/// <returns>A string containing the XML name for the enumeration value if an XmlEnumAttribute is applied; otherwise, the
+		/// default name of the enumeration value.</returns>
+		public static string ToXmlEnumString<T>(this T value) where T : Enum
+		{
+			var type = typeof(T);
+			var name = value.ToString();
+
+			var field = type.GetField(name);
+			var attr = field?.GetCustomAttribute<XmlEnumAttribute>();
+
+			return attr?.Name ?? name;
+		}
+	}
+}

--- a/Xbim.InformationSpecifications/IO/Xids.Io.xml.cs
+++ b/Xbim.InformationSpecifications/IO/Xids.Io.xml.cs
@@ -333,7 +333,7 @@ namespace Xbim.InformationSpecifications
 					xmlWriter.WriteStartElement("partOf", IdsNamespace);
 					WriteFacetBaseAttributes(pof, xmlWriter, logger, forRequirement, requirementOption);
 					if (pof.GetRelation() != PartOfFacet.PartOfRelation.Undefined)
-						xmlWriter.WriteAttributeString("relation", pof.GetRelation().ToString().ToUpperInvariant());
+						xmlWriter.WriteAttributeString("relation", pof.EntityRelation);
 					if (pof.EntityType is not null)
 					{
 						// forRequirement is false, because the minMax Occurs does not apply at this level.

--- a/Xbim.InformationSpecifications/Xbim.InformationSpecifications.csproj
+++ b/Xbim.InformationSpecifications/Xbim.InformationSpecifications.csproj
@@ -46,7 +46,7 @@
 		<None Include="..\README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="ids-lib" Version="1.0.102" />
+		<PackageReference Include="ids-lib" Version="1.0.107" />
 		<PackageReference Include="Nullable" Version="1.3.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
IDS changed the definition of IFCRELVOIDSELEMENT IFCRELFILLSELEMENT about 2 years ago. This pull request aligns the implementation with the schema.